### PR TITLE
Fix launching standalone app using `npm start`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/bin/
+bin/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "Dominions 5 Inspector",
-  "version": "5.15",
+  "name": "dominions5inspector",
+  "version": "5.15.0",
   "description": "A data inspector for Dominions 5.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Launching the standalone app by doing `npm start` was not working prior to this change due to an improperly formatted `package.json` file.