### PR TITLE
index.html : added id attribute to search-not checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
 				<div class = "property panel itemview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeyitem"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotitem">
 					<select tabindex="-1" class="search-comp" id="propcompitem">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -190,7 +190,7 @@
 				<div class = "property panel spellview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeyspell"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)" id="propnotspell">
 					<select tabindex="-1" class="search-comp" id="propcompspell">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -226,7 +226,7 @@
 				<div class = "property panel unitview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeyunit"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotunit">
 					<select tabindex="-1" class="search-comp" id="propcompunit">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -253,7 +253,7 @@
 				<div class = "property panel siteview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeysite"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotsite">
 					<select tabindex="-1" class="search-comp" id="propcompsite">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -279,7 +279,7 @@
 				<div class = "property panel mercview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeymerc"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotmerc">
 					<select tabindex="-1" class="search-comp" id="propcompmerc">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -317,7 +317,7 @@
 				<div class = "property panel eventview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeyevent"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotevent">
 					<select tabindex="-1" class="search-comp" id="propcompevent">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -343,7 +343,7 @@
 				<div class = "property panel wpnview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeywpn"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotwpn">
 					<select tabindex="-1" class="search-comp" id="propcompwpn">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>
@@ -370,7 +370,7 @@
 				<div class = "property panel armorview">
 					<input type="button" value="X" class="clear-filters-btn" title="clear filters" />
 					property (key):<input size="5" type="text" class="search-key" title="search for any named key" id="propkeyarmor"/>
-					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)">
+					!<input tabindex="-1" type="checkbox" class="search-not" title="not (opposite results)"  id="propnotarmor">
 					<select tabindex="-1" class="search-comp" id="propcomparmor">
 						<option title="regular expression match" class="default" selected="selected" value="=~">=~</option>
 						<option title="equals" value="==">==</option>


### PR DESCRIPTION
The search-not checkbox value wasn't being parsed into the permalink. Added an id attribute to each pages checkbox in the format id="propnot[page]" so they parse values to the query string.