### PR TITLE
Correcting modded spell and weapon displays, updated spec values

### DIFF
--- a/gamedata/effect_modifier_bits.csv
+++ b/gamedata/effect_modifier_bits.csv
@@ -9,7 +9,7 @@ bit_value	bit_name	test
 128	Armor Negating {Wpn: #armornegating}
 256	Soul Slaying {Wpn: #soulslaying}
 512	Chill/Cold {Wpn: #cold}
-1024	Unknown Modifier {Wpn: #1024}
+1024	? Unknown Modifier {Wpn: #1024}
 2048	Shock {Wpn: #shock}
 4096	Magic Resistance Negates {Wpn: #mrnegates}
 8192	Poison {Wpn: #poison}
@@ -20,7 +20,7 @@ bit_value	bit_name	test
 262144	Affects Enemies Only {Wpn: #friendlyimmune}
 524288	No Effect on Undead {Wpn: #undeadimmune}
 1048576	Defense Negate {Wpn: #defnegate}
-2097152	Hard to Hit Ethereal {Wpn: not #magic}
+2097152	Nonmagical {Wpn: not #magic}
 4194304	Affects Friendlies Only {Wpn: #enemyimmune}
 8388608	May Use Underwater {Wpn: #uwok}
 16777216	Magic Resistance Negates Easily {Wpn: #mrnegateseasily}
@@ -29,36 +29,36 @@ bit_value	bit_name	test
 134217728	Intrinsic Weapon {Wpn: #bonus}
 268435456	No effect on Demons {Wpn: #demonimmune}
 536870912	No effect on Inanimate {Wpn: #inanimateimmune}
-1073741824	Internally added to all spells {Wpn: #bloodletting}
+1073741824	Internally added to all spells {Wpn: #1073741824}
 2147483648	Damage Bonus on 1st Attack {Wpn: #charge}
 4294967296	Beam/Breath {Wpn: #beam}
 8589934592	Used in melee too {#usedinmelee}
 17179869184	50% chance to be used in melee too {Wpn: #range050}
-34359738368	Bypasses mirror image, internally added to spells with aoe 1+ {Wpn: #heavyweapon}
-68719476736	Higher charge bonus cap {Wpn: #68719476736}
+34359738368	Bypasses mirror image, internally added to spells with aoe 1+ {Wpn: #hasaoe}
+68719476736	Higher charge bonus cap {Wpn: #heavyweapon}
 137438953472	Cannot be used for repelling {Wpn: #norepel}
 274877906944	Piercing Damage {Wpn: #pierce}
 549755813888	Bludgeoning Damage {Wpn: #blunt}
 1099511627776	Slashing Damage {Wpn: #slash}
 2199023255552	Acid Damage {Wpn: #acid}
-4398046511104	Affects according to Target Size {Wpn: #sizeresist}
-8796093022208	Only a chance of this being used {Wpn: #melee50}
+4398046511104	Size or Strength negates {Wpn: #sizeresist}
+8796093022208	Only 50% chance of this being used {Wpn: #melee50}
 17592186044416	Magic Resistance Hard to Negate {Wpn: #hardmrneg}
-35184372088832	Attacks cannot be repelled {Wpn: #unrepel}
+35184372088832	Cannot be repelled {Wpn: #unrepel}
 70368744177664	No Effect on Fliers/Floaters {Wpn: #flyingimmune}
 140737488355328	Does not affect user unless hitting x% of battlefield {Wpn: #userimmune}
 281474976710656	Affects Animals Only {Wpn: #animalonly}
 562949953421312	More likely to hit head {#hithead}
-1125899906842624	? Ritual of Five Gates {Wpn: #fivegates}
-2251799813685248	? Add fire particles to weapon projectiles {Wpn: #2251799813685248}
+1125899906842624	Size negates (bugged, is never checked) {Wpn: #fivegates}
+2251799813685248	? Adds fire particles (weapon projectiles only) {Wpn: #fireparticles}
 4503599627370496	Creatures with Void Sanity immune {Wpn: #voidsanityimmune}
-9007199254740992	Ranged Special Attack {Wpn: #rangespec}
-18014398509481984	"True" Damage {Wpn: #18014398509481984}
+9007199254740992	Natural Ranged Weapon {Wpn: #natural}
+18014398509481984	"True" Damage {Wpn: #true}
 36028797018963968	Internal Damage {Wpn: #internal}
 72057594037927936	Magic Damage {Wpn: #dt_magic}
-144115188075855872	Projectiles fly along ground {Wpn: #144115188075855872}
+144115188075855872	Projectiles fly along ground {Wpn: #groundprojectile}
 288230376151711744	Half Strength added {Wpn: #halfstr}
 576460752303423488	Extra Effect {Wpn: #extraeffect}
 1152921504606846976	Extra Effect on Damage {Wpn: #extraeffectondmg}
-2305843009213693952	MR check Half Damage {Wpn: #mrcheckhalfdmg}
+2305843009213693952	MR check for Half Damage {Wpn: #mrcheckhalfdmg}
 4611686018427387904	One Third Strength added {Wpn: #bowstr}

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -1116,7 +1116,7 @@ MSpell.getEffect = function(spell) {
 		}
 		// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
 		// they should not retain the x% battlefield 
-		if ((effect.aoe < 600 || effect.aoe > 700) && effect.area_battlefield_pct) {
+		if ((spell.aoe < 600 || spell.aoe > 700) && effect.area_battlefield_pct) {
 			delete effect.area_battlefield_pct;
 		}
 	}

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -175,7 +175,7 @@ MSpell.prepareData_PostMod = function() {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
 					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
 					// they should not retain the x% battlefield 
-					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct)
+					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct) {
 						delete o.area_battlefield_pct;
 					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -173,6 +173,11 @@ MSpell.prepareData_PostMod = function() {
 				var area_per_level = parseInt(effects.area_per_level)%10;
 				if (area_per_level != 0) {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
+					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
+					// they should not retain the x% battlefield 
+					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct)
+						delete o.area_battlefield_pct;
+					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";
 				}
 				if (o.aoe_s == "0") {

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -173,11 +173,6 @@ MSpell.prepareData_PostMod = function() {
 				var area_per_level = parseInt(effects.area_per_level)%10;
 				if (area_per_level != 0) {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
-					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
-					// they should not retain the x% battlefield 
-					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct) {
-						delete o.area_battlefield_pct;
-					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";
 				}
 				if (o.aoe_s == "0") {
@@ -1118,6 +1113,11 @@ MSpell.getEffect = function(spell) {
 		effect.area_per_level = parseInt(spell.aoe) / 1000;
 		if (parseInt(spell.aoe) > 999) {
 			effect.area_per_level = Math.round(parseInt(spell.aoe) / 1000);
+		}
+		// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
+		// they should not retain the x% battlefield 
+		if ((effect.aoe < 600 || effect.aoe > 700) && effect.area_battlefield_pct) {
+			delete effect.area_battlefield_pct;
 		}
 	}
 

--- a/scripts/DMI/MWpn.js
+++ b/scripts/DMI/MWpn.js
@@ -15,7 +15,7 @@ var modconstants = DMI.modconstants;
 
 MWpn.initWpn = function(o) {
 	o.used_by = [];
-	o.att = 10;
+	o.att = 0;
 }
 
 MWpn.prepareData_PreMod = function() {


### PR DESCRIPTION
The previous commit to dom5utils that introduced reading the last two bytes of weapon spec values has made "fivegates" show up on the coral blade and duskdagger's secondary bleed effect. Apparently this has already confused at least one person, so renaming it seemed worthwhile.

Turns out that this flag currently does nothing but is displayed by the game as "can be negated by large beings". I also went and changed various other text in the spec flag file to better reflect what it actually means in game.