### PR TITLE
Fix for all weapons showing as magical

### DIFF
--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -173,11 +173,6 @@ MSpell.prepareData_PostMod = function() {
 				var area_per_level = parseInt(effects.area_per_level)%10;
 				if (area_per_level != 0) {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
-					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
-					// they should not retain the x% battlefield 
-					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct) {
-						delete o.area_battlefield_pct;
-					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";
 				}
 				if (o.aoe_s == "0") {

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -175,7 +175,7 @@ MSpell.prepareData_PostMod = function() {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
 					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
 					// they should not retain the x% battlefield 
-					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct)
+					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct) {
 						delete o.area_battlefield_pct;
 					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -173,6 +173,11 @@ MSpell.prepareData_PostMod = function() {
 				var area_per_level = parseInt(effects.area_per_level)%10;
 				if (area_per_level != 0) {
 					o.aoe_s = parseInt(o.aoe_s) + (parseInt(o.pathlevel1) * parseInt(area_per_level));
+					// In the case of modded spells that #copyspell a x% battlefield spell, but then overwrite aoe_s...
+					// they should not retain the x% battlefield 
+					if ((o.aoe_s < 600 || o.aoe_s > 700) && o.area_battlefield_pct)
+						delete o.area_battlefield_pct;
+					}
 					o.aoe_s = o.aoe_s + "+ [" + area_per_level + "/lvl]";
 				}
 				if (o.aoe_s == "0") {

--- a/scripts/DMI/MWpn.js
+++ b/scripts/DMI/MWpn.js
@@ -409,7 +409,7 @@ MWpn.bitfieldValues = function(bitfield, masks_dict, o) {
 	var newValues=[];
 	var values = bitfields.bitfieldValues(bitfield, masks_dict);
 	for (var value in values) {
-		if (values[value].indexOf("Hard to Hit Ethereal") != -1) {
+		if (values[value].indexOf("Nonmagical") != -1) {
 			magic = false;
 		} else if (values[value].indexOf("Adds Strength of Wielder") != -1) {
 			nostr = false;


### PR DESCRIPTION
I did not expect renaming "Hard to hit ethereal" to the more natural "Nonmagical" to cause issues, but it made all weapons bebcome marked as magical and ALSO to be marked as nonmagical if they were in fact nonmagical. This seems to have been causing widespread confusion.