### PR TITLE
Avoid mod-nation infinite nextspell loop 

### DIFF
--- a/scripts/DMI/MNation.js
+++ b/scripts/DMI/MNation.js
@@ -400,6 +400,7 @@ MNation.prepareData_PostMod = function() {
 							other.nationname = 'various ('+ncount+')';
 					}
 				}
+				if ( spell == spell.nextspell ) break; // avoid infinite loop
 			} while (spell = spell.nextspell);
 		}
 


### PR DESCRIPTION
Thank you very much for this incredible tool!

I noticed that the Confluence mod accidentally avoids the nextspell infinite-loop detection. I've added an additional check for self-loops in `MNation.js`, which makes Confluence load and fixes issue #43 .