### PR TITLE
Fix reanimation search

### DIFF
--- a/scripts/modconstants.js
+++ b/scripts/modconstants.js
@@ -58,7 +58,9 @@ DMI.propertyAliases =  {
 	nomind: 'mind',
 
 	//items
-	quick: 'quickness'
+	quick: 'quickness',
+	reanimh: 'reanimH',
+	reanimd: 'reanimD'
 }
 
 			


### PR DESCRIPTION
Fixes #45 by adding property aliases for `reanimh` and `reanimd` to `reanimH` and `reanimD`. 