### PR TITLE
Allow special province IDs for effect 108

### DIFF
--- a/scripts/DMI/MWpn.js
+++ b/scripts/DMI/MWpn.js
@@ -48,7 +48,11 @@ MWpn.prepareData_PostMod = function() {
 					}
 				}
 			} else if (effects.effect_number == "108") {
-				o.dmg = modctx.other_planes_lookup[parseInt(effects.raw_argument)].name;
+				if ( typeof modctx.other_planes_lookup[parseInt(effects.raw_argument)] !== 'undefined' ) {
+					o.dmg = modctx.other_planes_lookup[parseInt(effects.raw_argument)].name;
+				} else {
+					o.dmg = "Unknown plane " + effects.raw_argument;
+				}
 			} else if (parseInt(effects.effect_number) >= 500 && parseInt(effects.effect_number) <= 699) {
 				if (modctx.unit_effects_lookup[effects.raw_argument])
 				{


### PR DESCRIPTION
Mods with weapon effect number 108 and target planes other than -11, -12 and -13 (the Void, Inferno and Kokytos) can't be loaded due to plane name lookup failing. This pull request replaces the plane name with e.g. "Unknown plane: -8" for special province IDs instead of crashing.

I'd be happy to include names for the special province IDs instead if you prefer that solution.