### PR TITLE
Make unit map-move more correct and fix armor map-move penalty

### DIFF
--- a/scripts/DMI/MArmor.js
+++ b/scripts/DMI/MArmor.js
@@ -28,17 +28,6 @@ MArmor.prepareData_PreMod = function() {
 MArmor.prepareData_PostMod = function() {
 	for (var oi=0, o; o= modctx.armordata[oi]; oi++) {
 
-		o.movepen = o.enc;
-		for (var oi3=0, attr; attr = modctx.attributes_by_armor[oi3];  oi3++) {
-			if (attr.armor_number == o.id) {
-				if (parseInt(attr.attribute) == 582) {
-					o.movepen = attr.raw_value;
-				}
-			}
-		}
-		if (o.type != 5) {
-			delete o.movepen;
-		}
 
 		o.id = parseInt(o.id);
 		o.name = o.name || '(undefined)';
@@ -101,6 +90,24 @@ MArmor.prepareData_PostMod = function() {
 					o.magic = 1;
 				}
 			}
+		}
+
+		// movement penalty
+		o.movepen = o.enc;
+		if ( o.magic ) {
+			o.movepen -= 1;
+		}
+		o.movepen = Math.min( o.movepen * 2, 6 );
+		for (var oi3=0, attr; attr = modctx.attributes_by_armor[oi3];  oi3++) {
+			if (attr.armor_number == o.id) {
+				if (parseInt(attr.attribute) == 582 && attr.raw_value != -99) {
+					// overwrite above if movepen attribute is set
+					o.movepen = attr.raw_value;
+				}
+			}
+		}
+		if (o.type != 'armor') {
+			delete o.movepen;
 		}
 	}
 }

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -255,40 +255,6 @@ MUnit.prepareData_PostMod = function() {
 		if (!o.ap) {
 			o.ap = 12;
 		}
-		if (!o.mapmove) {
-			o.mapmove = 14;
-		} else {
-			// mapmove formula extracted from 5.54 binary
-			var mm = parseInt(o.mapmove);
-			if ( mm < 100 ) {
-				if ( mm < 6 ) {
-					mm = mm * 6 + 2;
-					if ( o.flying ) {
-						mm += 6;
-					}
-					if ( o.slave ) {
-						mm -= 2;
-					}
-				}
-				if ( isCmdr(o) ) {
-					mm += 2;
-				}
-				if ( mm > 40 ) {
-					mm = Math.floor( (mm+2)/5 ) * 5;
-				}
-			}
-			if ( mm > 0 && mm < 100 ) {
-				// Not yet implemented: old age penalty, how to find which commanders are old?
-			}
-			if ( ! o.nomovepen ) {
-				// Not yet implemented: armour map move penalty
-			}
-			// Map move effects omitted due to not applicable in inspector:
-			//   - enlarged/shrunk effect
-			//   - limp/crippled commander
-			//   - items
-			o.mapmove = mm;
-		}
 
 		if (o.realms && o.realms.length == 0) {
 			delete o.realms;
@@ -931,6 +897,48 @@ MUnit.prepareData_PostSiteData = function(o) {
 			o.listed_mpath = '0'+o.mpath;
 		else o.listed_mpath = '';
 
+		// Map move
+		
+		if (!o.mapmove) {
+			o.mapmove = 14;
+		} else {
+			// mapmove formula extracted from 5.54 binary
+			var mm = parseInt(o.mapmove);
+			if ( mm < 100 ) {
+				if ( mm < 6 ) {
+					mm = mm * 6 + 2;
+					if ( o.flying ) {
+						mm += 6;
+					}
+					if ( o.slave ) {
+						mm -= 2;
+					}
+				}
+				if ( isCmdr(o) ) {
+					mm += 2;
+				}
+				if ( mm > 40 ) {
+					mm = Math.floor( (mm+2)/5 ) * 5;
+				}
+			}
+			if ( mm > 0 && mm < 100 ) {
+				// Not yet implemented: old age penalty, how to find which commanders are old?
+			}
+			if ( ! o.nomovepen ) {
+				// Not yet implemented: armour map move penalty
+				var armour_penalty = 0;
+				for (var i=0, a; a= o.armor[i]; i++) {
+					//..
+				}
+				mm -= armour_penalty;
+			}
+			// Map move effects omitted due to not applicable in inspector:
+			//   - enlarged/shrunk effect
+			//   - limp/crippled commander
+			//   - items
+			o.mapmove = mm;
+		}
+
 		o.unprep = true;
 	}
 }
@@ -1233,13 +1241,12 @@ MUnit.prepareForRender = function(o) {
 		var p_nat = parseInt(o.prot || '0');
 
 		var p_body = 0, p_head = 0, p_general = 0;
-		var def_armor = 0, enc_armor = 0, mm_armor = 0;
+		var def_armor = 0, enc_armor = 0;
 		var def_parry = 0;
 		var rcost_armor = 0;
 		for (var i=0, a; a= o.armor[i]; i++) {
 			enc_armor += parseInt(a.enc || '0');
 			def_armor += parseInt(a.def || '0');
-			mm_armor += parseInt(a.movepen || '0');
 
 			if (a.protbody)
 				p_body = parseInt(a.protbody);
@@ -1321,11 +1328,6 @@ MUnit.prepareForRender = function(o) {
 			}
 		}
 
-		if (mm_armor) {
-			// Map move effected by armor
-			bonus('armor', 'mapmove', -mm_armor);
-
-		}
 	}
 }
 

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -931,15 +931,7 @@ MUnit.prepareData_PostSiteData = function(o) {
 					if (a.type != 'armor') {
 						continue;
 					}
-					if ( a.movepen && parseInt( a.movepen ) != -99 ) {
-						armor_penalty += parseInt( a.movepen );
-					} else {
-						var armor_enc = parseInt( a.enc );
-						if ( a.magic ) {
-							armor_enc--;
-						}
-						armor_penalty += Math.max( armor_enc * 2, 6 );
-					}
+					armor_penalty += a.movepen; // movepen calculated from movepen attribute in MArmor.js
 				}
 				if ( o.enc == 0 ) {
 					armor_penalty = Math.floor( armor_penalty / 2 );

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -902,7 +902,8 @@ MUnit.prepareData_PostSiteData = function(o) {
 		if (!o.mapmove) {
 			o.mapmove = 14;
 		} else {
-			// mapmove formula extracted from 5.54 binary
+			// Map move formula extracted from 5.54 binary,
+			// see Loggy's notes: https://illwiki.com/dom5/user/loggy/misc
 			var mm = parseInt(o.mapmove);
 			if ( mm < 100 ) {
 				if ( mm < 6 ) {
@@ -925,12 +926,25 @@ MUnit.prepareData_PostSiteData = function(o) {
 				// Not yet implemented: old age penalty, how to find which commanders are old?
 			}
 			if ( ! o.nomovepen ) {
-				// Not yet implemented: armour map move penalty
-				var armour_penalty = 0;
+				var armor_penalty = 0;
 				for (var i=0, a; a= o.armor[i]; i++) {
-					//..
+					if (a.type != 'armor') {
+						continue;
+					}
+					if ( a.movepen && parseInt( a.movepen ) != -99 ) {
+						armor_penalty += parseInt( a.movepen );
+					} else {
+						var armor_enc = parseInt( a.enc );
+						if ( a.magic ) {
+							armor_enc--;
+						}
+						armor_penalty += Math.max( armor_enc * 2, 6 );
+					}
 				}
-				mm -= armour_penalty;
+				if ( o.enc == 0 ) {
+					armor_penalty = Math.floor( armor_penalty / 2 );
+				}
+				mm -= armor_penalty;
 			}
 			// Map move effects omitted due to not applicable in inspector:
 			//   - enlarged/shrunk effect

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -258,11 +258,36 @@ MUnit.prepareData_PostMod = function() {
 		if (!o.mapmove) {
 			o.mapmove = 14;
 		} else {
-			if (o.flying && parseInt(o.mapmove) < 10) {
-				o.mapmove = parseInt(o.mapmove)*6 + 10;
-			} else {
-				o.mapmove = parseInt(o.mapmove) + 2;
+			// mapmove formula extracted from 5.54 binary
+			var mm = parseInt(o.mapmove);
+			if ( mm < 100 ) {
+				if ( mm < 6 ) {
+					mm = mm * 6 + 2;
+					if ( o.flying ) {
+						mm += 6;
+					}
+					if ( o.slave ) {
+						mm -= 2;
+					}
+				}
+				if ( isCmdr(o) ) {
+					mm += 2;
+				}
+				if ( mm > 40 ) {
+					mm = Math.floor( (mm+2)/5 ) * 5;
+				}
 			}
+			if ( mm > 0 && mm < 100 ) {
+				// Not yet implemented: old age penalty, how to find which commanders are old?
+			}
+			if ( ! o.nomovepen ) {
+				// Not yet implemented: armour map move penalty
+			}
+			// Map move effects omitted due to not applicable in inspector:
+			//   - enlarged/shrunk effect
+			//   - limp/crippled commander
+			//   - items
+			o.mapmove = mm;
 		}
 
 		if (o.realms && o.realms.length == 0) {


### PR DESCRIPTION
Hi Larz,

Thanks to [Loggy's reverse engineering](https://illwiki.com/dom5/user/loggy/misc), it's now known how in-game unit map move is calculated after the dom4->5 change. I've implemented the calculation in this PR. As far as I can tell from random samples, it matches in-game map move.

It isn't known completely how to tell which units are old, so I've ignored the old-age penalty. Map move for old units will still be off by 2-6. If you'd prefer, I could add some mostly-correct heuristic. Armor map-move penalty calculation was also corrected.

Thank you again for this stellar tool!