### PR TITLE
Trim the text search box

### DIFF
--- a/scripts/DMI/MArmor.js
+++ b/scripts/DMI/MArmor.js
@@ -134,7 +134,7 @@ MArmor.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
 

--- a/scripts/DMI/MEvent.js
+++ b/scripts/DMI/MEvent.js
@@ -169,10 +169,10 @@ MEvent.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = Utils.merge(this.getPropertyMatchArgs(), {
-			str: $(that.domselp+" input.search-box").val().toLowerCase()
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim()
 		});
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
 

--- a/scripts/DMI/MItem.js
+++ b/scripts/DMI/MItem.js
@@ -251,7 +251,7 @@ MItem.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 			type: Utils.splitToLookup( $(that.domselp+" select.type").val(), ','),
 			constlevel: parseInt( $(that.domselp+" select.constlevel").val() ),
 			inclusive: $(that.domselp+" input.inclusive-search:checked").val(),

--- a/scripts/DMI/MMerc.js
+++ b/scripts/DMI/MMerc.js
@@ -61,7 +61,7 @@ MMerc.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
 

--- a/scripts/DMI/MSite.js
+++ b/scripts/DMI/MSite.js
@@ -428,7 +428,7 @@ MSite.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 			sitepath: $(that.domselp+" select.sitepath").val() ,
 			sitescale: $(that.domselp+" select.sitescale").val() ,
 			siteterrain: $(that.domselp+" select.siteterrain").val() ,

--- a/scripts/DMI/MSpell.js
+++ b/scripts/DMI/MSpell.js
@@ -560,7 +560,7 @@ MSpell.CGrid = DMI.Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function(domsel) {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 			nation: $(that.domselp+" select.nation").val(),
 
 			type: $(that.domselp+" select.type").val(),

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -1400,7 +1400,7 @@ MUnit.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function(domsel) {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 			nation: $(that.domselp+" select.nation").val(),
 			types: Utils.splitToLookup( $(that.domselp+" select.typechar").val(), ','),
 			generic: $(that.domselp+" input.generic:checked").val(),

--- a/scripts/DMI/MWpn.js
+++ b/scripts/DMI/MWpn.js
@@ -138,7 +138,7 @@ MWpn.CGrid = Utils.Class( DMI.CGrid, function() {
 	//reads search boxes
 	this.getSearchArgs = function() {
 		var args = {properties: this.getPropertyMatchArgs(),
-			str: $(that.domselp+" input.search-box").val().toLowerCase(),
+			str: $(that.domselp+" input.search-box").val().toLowerCase().trim(),
 		};
 		args.properties = Utils.propertiesWithKeys(args.properties);
 

--- a/scripts/ParsedQueryString.js
+++ b/scripts/ParsedQueryString.js
@@ -43,9 +43,10 @@ ParsedQueryString.prototype =
 				var name = this._decodeURL(pair[0]);
 				if (Boolean(pair[1]))
 				{
-					var value = this._decodeURL(pair[1]);
+					var value = this._decodeURL(pair[1]).trim();
+
 					if (Boolean(this._parameters[name]))
-						this._parameters[name].push(value);
+						this._parameters[name].push(value.trim());
 					else
 						this._parameters[name] = [value];
 				}


### PR DESCRIPTION
Noticed when pasting names of things from other websites or refreshing the page and parsing the query params: any spaces on outside of the text search gives no results.  Would be nice to simply trim the whitespace on outside of searches.

With changes:
![image](https://user-images.githubusercontent.com/11811765/161367178-e600da4d-51c9-4744-9940-dbd35cd91bf4.png)


![image](https://user-images.githubusercontent.com/11811765/161367274-16de4ccb-634c-4cf8-a6c3-9cd5d2e0d154.png)
