### PR TITLE
Tag storm-power units/items with storm-immune (fixes #56)

### DIFF
--- a/scripts/DMI/MItem.js
+++ b/scripts/DMI/MItem.js
@@ -150,6 +150,11 @@ MItem.prepareData_PostMod = function() {
 				o.boosters += p;
 		}
 
+		// storm power grants storm-immune
+		if (o.stormpower && o.stormpower > 0) {
+			o.stormimmune = '1';
+		}
+
 		//lookup weapon
 		if (o.weapon) {
 			w = modctx.wpnlookup[o.weapon];

--- a/scripts/DMI/MUnit.js
+++ b/scripts/DMI/MUnit.js
@@ -301,6 +301,11 @@ MUnit.prepareData_PostMod = function() {
 			delete o.horror;
 		}
 
+		// storm power grants storm-immune
+		if (o.stormpower && o.stormpower > 0) {
+			o.stormimmune = '1';
+		}
+
 		//searchable string
 		o.searchable = o.fullname.toLowerCase();
 


### PR DESCRIPTION
Hi Larz,

Dom5 adds the storm-immune tag to all units with storm-power, but the inspector only includes the tag when explicit in the unit data. This PR adds the implied storm-immune tag to storm-power units and items.

Affected units and items:  Pazuzu (446), Sylph (562), Storm Demon (632), Fadmargast (647), Abductor's eagle shape (1383), Rudra (1906), Shed (2073), Kavi Archer (2558), and Igor Könhelm's Tome.

In-game, the tag is added in the UI as seen in this disassembly, courtesy of Loggy:

![image](https://user-images.githubusercontent.com/1546926/177143567-8d623096-88f2-43ef-90ed-5eb9e0c3e62f.png)

Please let me know if you'd prefer solving this in some other way, and I'll be happy to amend the PR.

Cheers,
Tim