### PR TITLE
Update parsemod.js

### DIFF
--- a/scripts/parsemod.js
+++ b/scripts/parsemod.js
@@ -345,7 +345,18 @@ var modctx = DMI.modctx = {
 			modctx._new(c, {n1:id} ,'spell',fnw);
 			DMI.MSpell.initSpell(modctx.spell);
 		},
-		selectspell: function(c,a,t,fnw){ modctx._select(c,a,'spell',fnw); },
+		selectspell: function(c,a,t,fnw){ 
+			try {
+				modctx._select(c,a,'spell',fnw);
+			}
+			catch(e) {
+				if (e == 'data not found' && a.n1) {
+					modctx._new(c,a,'spell',fnw);
+					DMI.MSpell.initSpell(modctx.spell);
+				}
+				else throw e;
+			}
+		},
 
 		newnation: function(c,a,t,fnw) {
 			//get first unused id


### PR DESCRIPTION
You can use #selectspell to specify ID's in mods and give a spell a fixed ID - however the inspector will not initialize them correctly, and so national spells that are given a fixed ID are not displayed correctly.