### PR TITLE
Force string before calling toLowerCase()

### DIFF
--- a/scripts/DMI/MSite.js
+++ b/scripts/DMI/MSite.js
@@ -130,7 +130,7 @@ MSite.prepareData_PostMod = function() {
 		}
 
 		//searchable string
-		o.searchable = o.name.toLowerCase();
+		o.searchable = o.name.toString().toLowerCase();
 
 		if (o.scale1) {
 			o.scales.push(o.scale1);


### PR DESCRIPTION
My chrome browser (despite deleting cookies and all local site data) cannot load dom5inspector because of toLowerCase being called.  Not sure how I got into this state - some bad character or bad type being in a site? Or one of them is null/undefined?

![image](https://github.com/larzm42/dom5inspector/assets/11811765/51488d67-d31f-45e5-8aa1-bb307f3e3e5b)


![image](https://github.com/larzm42/dom5inspector/assets/11811765/0a9ad582-ef49-4c11-be95-d3551914699b)
